### PR TITLE
Removed the en_AU & Australia/Sydey regional timezone/locale setting

### DIFF
--- a/4.5/lucee-web.xml.cfm
+++ b/4.5/lucee-web.xml.cfm
@@ -109,9 +109,9 @@ Path placeholders:
 			define where lucee first look for a called cfml file.
 			for example when you define physical you can partiquel overwrite the archive.
 		-->
-		
+
 		<!-- <mapping archive="{lucee-web}/context/lucee-context.lar" physical="{lucee-web}/context/" primary="physical" readonly="yes" toplevel="yes" trusted="true" virtual="/lucee/"/>  -->
-		
+
 	</mappings>
 
 	<custom-tag>
@@ -145,7 +145,6 @@ Path placeholders:
 		timeserver: [example: swisstime.ethz.ch] default:local time
 			dns of a ntp time server
 	-->
-	<regional locale="en_AU" timezone="Australia/Sydney"/>
 
 	<!--
 		enable and disable debugging

--- a/5.0/lucee-web.xml.cfm
+++ b/5.0/lucee-web.xml.cfm
@@ -109,9 +109,9 @@ Path placeholders:
 			define where lucee first look for a called cfml file.
 			for example when you define physical you can partiquel overwrite the archive.
 		-->
-		
+
 		<!-- <mapping archive="{lucee-web}/context/lucee-context.lar" physical="{lucee-web}/context/" primary="physical" readonly="yes" toplevel="yes" trusted="true" virtual="/lucee/"/>  -->
-		
+
 	</mappings>
 
 	<custom-tag>
@@ -145,7 +145,6 @@ Path placeholders:
 		timeserver: [example: swisstime.ethz.ch] default:local time
 			dns of a ntp time server
 	-->
-	<regional locale="en_AU" timezone="Australia/Sydney"/>
 
 	<!--
 		enable and disable debugging


### PR DESCRIPTION
I wanted to make the Docker more generic rather than having a timezone and region already set.
