### PR TITLE
Replace stock Lucee cacerts file with the Debian Maintained one

### DIFF
--- a/4.5/Dockerfile
+++ b/4.5/Dockerfile
@@ -34,3 +34,7 @@ ONBUILD RUN rm -rf /var/www/*
 RUN /usr/local/tomcat/bin/catalina.sh start && \
     while [ ! -f "/opt/lucee/web/logs/application.log" ] ; do sleep 2; done && \
     /usr/local/tomcat/bin/catalina.sh stop
+
+# Replace the Trusted SSL Certificates packaged with Lucee with those from Debian
+#   ca-certificates package from the OS is the most recent authority
+RUN cp -f /etc/ssl/certs/java/cacerts /opt/lucee/server/lucee-server/context/security/cacerts

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -34,3 +34,7 @@ ONBUILD RUN rm -rf /var/www/*
 RUN /usr/local/tomcat/bin/catalina.sh start && \
     while [ ! -f "/opt/lucee/web/logs/application.log" ] ; do sleep 2; done && \
     /usr/local/tomcat/bin/catalina.sh stop
+
+# Replace the Trusted SSL Certificates packaged with Lucee with those from Debian
+#   ca-certificates package from the OS is the most recent authority
+RUN cp -f /etc/ssl/certs/java/cacerts /opt/lucee/server/lucee-server/context/security/cacerts


### PR DESCRIPTION
Debian's cacerts file is based on their ca-certificates package,
which is updated by their package maintainers, and as such is likely
to have a more recent list than the one included in Lucee's git.

Later builds in the chain can still use keytool to inject certificates
as usual.
