### PR TITLE
make prewarm more reliable

### DIFF
--- a/5.2/prewarm.sh
+++ b/5.2/prewarm.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
+set -e
 
 /usr/local/tomcat/bin/catalina.sh start
-while [ ! -f "/opt/lucee/web/logs/application.log" ] ; do sleep 2; done && \
+while [ ! -f "/opt/lucee/web/logs/application.log" ] ; do sleep 2; done
+while [ ! -d "/opt/lucee/server/lucee-server/deploy" ] ; do sleep 2; done
+sleep 1
 /usr/local/tomcat/bin/catalina.sh stop
 rm -rf /opt/lucee/web/logs/*


### PR DESCRIPTION
You could run this build 99 times successfully, but on the 100th time, you could run into a missing `deploy` directory (seems to be the very last thing that's created during warmup). That causes problems for extension installations down the line.

The check for the `deploy` directory makes the build more reliable.