### PR TITLE
Fix administrator redirect

### DIFF
--- a/lucee-nginx/5.2/default.conf
+++ b/lucee-nginx/5.2/default.conf
@@ -36,9 +36,14 @@ server {
   location ~* /lucee/ {
     # allow 10.0.0.1; # Add your IP address here
     deny all; # block access
+    try_files @lucee @lucee;
   }
 
   location ~* \.(cfm|cfc|cfr)$ {
+    try_files @lucee @lucee;
+  }
+  
+  location @lucee {
       proxy_pass http://127.0.0.1:8888;
       proxy_redirect off;
       proxy_set_header Host $host;


### PR DESCRIPTION
/lucee/ block is the only block evaluated because when regex blocks are matched, the first match (and ONLY the first match) wins.

Need to forward on to lucee appropriately.