### PR TITLE
Fix error message in multi-host configuratiion

### DIFF
--- a/5.3/web.xml
+++ b/5.3/web.xml
@@ -4622,7 +4622,7 @@
         </init-param>
         <init-param>
             <param-name>lucee-web-directory</param-name>
-            <param-value>/opt/lucee/web/</param-value>
+            <param-value>/opt/lucee/web/{web-context-label}</param-value>
             <description>Lucee Web Directory (for Website-specific configurations, settings, and libraries)</description>
         </init-param>
         <load-on-startup>1</load-on-startup>


### PR DESCRIPTION
When the tomcat is configured for multiple hosts, the following message is being displayed on startup:
"static path [/opt/lucee/web/] for servlet init param [lucee-web-directory] is not allowed. Path must use a web context specific placeholder"
Tha cause is a hardcoded lucee-web-directory.