### PR TITLE
update default version for 6.1

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -60,7 +60,7 @@ tags:
 
   '6.1': &6_1
     TOMCAT_VERSION: '9.0'
-    TOMCAT_JAVA_VERSION: 'jre11-temurin-jammy'
+    TOMCAT_JAVA_VERSION: 'jre21-temurin-jammy'
     TOMCAT_BASE_IMAGE: ''
     LUCEE_MINOR: '6.1'
     LUCEE_SERVER: ''


### PR DESCRIPTION
By default use Java 21 for Lucee 6.1